### PR TITLE
fix that weird bug

### DIFF
--- a/headers/force.h
+++ b/headers/force.h
@@ -11,10 +11,10 @@
 #include "universe.h"
 #include "vec3.h"
 
-universe_t *force_bond(vec3_t *frc, universe_t *universe, const size_t a1, const size_t a2);
-universe_t *force_electrostatic(vec3_t *frc, universe_t *universe, const size_t a1, const size_t a2);
-universe_t *force_lennardjones(vec3_t *frc, universe_t *universe, const size_t a1, const size_t a2);
-universe_t *force_angle(vec3_t *frc, universe_t *universe, const size_t a1, const size_t a2);
-universe_t *force_total(vec3_t *frc, universe_t *universe, const size_t atom_id);
+universe_t *force_bond(vec3_t *frc, universe_t *universe, const uint64_t a1, const uint64_t a2);
+universe_t *force_electrostatic(vec3_t *frc, universe_t *universe, const uint64_t a1, const uint64_t a2);
+universe_t *force_lennardjones(vec3_t *frc, universe_t *universe, const uint64_t a1, const uint64_t a2);
+universe_t *force_angle(vec3_t *frc, universe_t *universe, const uint64_t a1, const uint64_t a2);
+universe_t *force_total(vec3_t *frc, universe_t *universe, const uint64_t atom_id);
 
 #endif

--- a/headers/potential.h
+++ b/headers/potential.h
@@ -12,10 +12,10 @@
 
 #include "universe.h"
 
-universe_t *potential_bond(double *pot, universe_t *universe, const size_t a1, const size_t a2);
-universe_t *potential_electrostatic(double *pot, universe_t *universe, const size_t a1, const size_t a2);
-universe_t *potential_lennardjones(double *pot, universe_t *universe, const size_t a1, const size_t a2);
-universe_t *potential_angle(double *pot, universe_t *universe, const size_t a1, const size_t a2);
-universe_t *potential_total(double *pot, universe_t *universe, const size_t atom_id);
+universe_t *potential_bond(double *pot, universe_t *universe, const uint64_t a1, const uint64_t a2);
+universe_t *potential_electrostatic(double *pot, universe_t *universe, const uint64_t a1, const uint64_t a2);
+universe_t *potential_lennardjones(double *pot, universe_t *universe, const uint64_t a1, const uint64_t a2);
+universe_t *potential_angle(double *pot, universe_t *universe, const uint64_t a1, const uint64_t a2);
+universe_t *potential_total(double *pot, universe_t *universe, const uint64_t atom_id);
 
 #endif

--- a/headers/universe.h
+++ b/headers/universe.h
@@ -131,7 +131,7 @@ struct universe_s
 /* The following functions operate on the atom_s structure */
 void        atom_init(atom_t *atom);
 void        atom_clean(atom_t *atom);
-int         atom_is_bonded(universe_t *universe, const uint8_t a1, const uint8_t a2);
+int         atom_is_bonded(universe_t *universe, const uint64_t a1, const uint64_t a2);
 universe_t *atom_update_frc_numerical(universe_t *universe, const uint64_t atom_id);
 universe_t *atom_update_frc_analytical(universe_t *universe, const uint64_t atom_id);
 universe_t *atom_update_acc(universe_t *universe, const uint64_t atom_id);

--- a/sources/atom.c
+++ b/sources/atom.c
@@ -229,7 +229,7 @@ universe_t *atom_enforce_pbc(universe_t *universe, const uint64_t atom_id)
 }
 
 /* Returns 0 if a1 is not bonded to a2, returns 1 if it is bonded to a2 */
-int atom_is_bonded(universe_t *universe, const uint8_t a1, const uint8_t a2)
+int atom_is_bonded(universe_t *universe, const uint64_t a1, const uint64_t a2)
 {
   atom_t *atom_1;
   size_t i;

--- a/sources/force.c
+++ b/sources/force.c
@@ -14,7 +14,7 @@
 #include "universe.h"
 #include "util.h"
 
-universe_t *force_bond(vec3_t *frc, universe_t *universe, const size_t a1, const size_t a2)
+universe_t *force_bond(vec3_t *frc, universe_t *universe, const uint64_t a1, const uint64_t a2)
 {
   atom_t *atom_1;
   atom_t *atom_2;
@@ -63,7 +63,7 @@ universe_t *force_bond(vec3_t *frc, universe_t *universe, const size_t a1, const
   return (universe);
 }
 
-universe_t *force_electrostatic(vec3_t *frc, universe_t *universe, const size_t a1, const size_t a2)
+universe_t *force_electrostatic(vec3_t *frc, universe_t *universe, const uint64_t a1, const uint64_t a2)
 {
   atom_t *atom_1;
   atom_t *atom_2;
@@ -92,7 +92,7 @@ universe_t *force_electrostatic(vec3_t *frc, universe_t *universe, const size_t 
   return (universe);
 }
 
-universe_t *force_lennardjones(vec3_t *frc, universe_t *universe, const size_t a1, const size_t a2)
+universe_t *force_lennardjones(vec3_t *frc, universe_t *universe, const uint64_t a1, const uint64_t a2)
 {
   atom_t *atom_1;
   atom_t *atom_2;
@@ -141,7 +141,7 @@ universe_t *force_lennardjones(vec3_t *frc, universe_t *universe, const size_t a
   return (universe);
 }
 
-universe_t *force_angle(vec3_t *frc, universe_t *universe, const size_t a1, const size_t a2)
+universe_t *force_angle(vec3_t *frc, universe_t *universe, const uint64_t a1, const uint64_t a2)
 {
   /* This function is a bit complex so here is a rundown:
    * a1 is bonded to a2, but a2 can be bonded to more atoms.
@@ -291,9 +291,9 @@ universe_t *force_angle(vec3_t *frc, universe_t *universe, const size_t a1, cons
   return (universe);
 }
 
-universe_t *force_total(vec3_t *frc, universe_t *universe, const size_t atom_id)
+universe_t *force_total(vec3_t *frc, universe_t *universe, const uint64_t atom_id)
 {
-  size_t i;
+  uint64_t i;
   vec3_t to_target;
   vec3_t pos_backup;
   vec3_t vec_bond;

--- a/sources/potential.c
+++ b/sources/potential.c
@@ -16,7 +16,7 @@
 #include "util.h"
 #include "vec3.h"
 
-universe_t *potential_bond(double *pot, universe_t *universe, const size_t a1, const size_t a2)
+universe_t *potential_bond(double *pot, universe_t *universe, const uint64_t a1, const uint64_t a2)
 {
   atom_t *atom_1;
   atom_t *atom_2;
@@ -57,7 +57,7 @@ universe_t *potential_bond(double *pot, universe_t *universe, const size_t a1, c
   return (universe);
 }
 
-universe_t *potential_electrostatic(double *pot, universe_t *universe, const size_t a1, const size_t a2)
+universe_t *potential_electrostatic(double *pot, universe_t *universe, const uint64_t a1, const uint64_t a2)
 {
   atom_t *atom_1;
   atom_t *atom_2;
@@ -82,7 +82,7 @@ universe_t *potential_electrostatic(double *pot, universe_t *universe, const siz
   return (universe);
 }
 
-universe_t *potential_lennardjones(double *pot, universe_t *universe, const size_t a1, const size_t a2)
+universe_t *potential_lennardjones(double *pot, universe_t *universe, const uint64_t a1, const uint64_t a2)
 {
   atom_t *atom_1;
   atom_t *atom_2;
@@ -129,7 +129,7 @@ universe_t *potential_lennardjones(double *pot, universe_t *universe, const size
   return (universe);
 }
 
-universe_t *potential_angle(double *pot, universe_t *universe, const size_t a1, const size_t a2)
+universe_t *potential_angle(double *pot, universe_t *universe, const uint64_t a1, const uint64_t a2)
 {
   /* This function is a bit complex so here is a rundown:
    * a1 is bonded to a2, but a2 can be bonded to more atoms.
@@ -228,7 +228,7 @@ universe_t *potential_angle(double *pot, universe_t *universe, const size_t a1, 
   return (universe);
 }
 
-universe_t *potential_total(double *pot, universe_t *universe, const size_t atom_id)
+universe_t *potential_total(double *pot, universe_t *universe, const uint64_t atom_id)
 {
   size_t i;
   vec3_t to_target;


### PR DESCRIPTION
The function atom_is_bonded accepted the atom IDs as `uint8_t`, which is too narrow and causes it to check the wrong atoms for high atom IDs. This PR fixes that bug and also unifies all atom IDs to `uint64_t`.