### PR TITLE
Allow the user to specify a seed for srand

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Options:
 
 - `--reduce_potential` Reduces the potential energy to the provided value (pJ) or lower (defaults to 10 pJ)
 
-- `--srand` Specifies an integer seed for randomization.  If the seed is not specified, the program will default to a random-enough seed.
+- `--srand` Specifies an unsigned integer seed for randomization.  If the seed is not specified, the program will default to a random-enough seed.
 
 ## Example use
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Options:
 
 - `--reduce_potential` Reduces the potential energy to the provided value (pJ) or lower (defaults to 10 pJ)
 
+- `--srand` Specifies an integer seed for randomization.  If the seed is not specified, the program will default to a random-enough seed.
+
 ## Example use
 
 `$ ./senpai.bin --in examples/DES.mol --solvent examples/water.mol --out render.xyz`

--- a/headers/args.h
+++ b/headers/args.h
@@ -24,6 +24,7 @@
 #define FLAG_REDUCEPOT  "--reduce_potential"
 #define FLAG_SOLVENT    "--solvent"
 #define FLAG_MODEL      "--model"
+#define FLAG_SRAND_SEED "--srand"
 
 /* t_args */
 #define ARGS_PATH_SUBSTRATE_DEFAULT    ((char*)NULL)      /* Path to the MDS substrate file */
@@ -39,6 +40,7 @@
 #define ARGS_DENSITY_DEFAULT           ((double)1E0)      /* Density (g.cm-3) */
 #define ARGS_FRAMESKIP_DEFAULT         ((uint64_t)0)      /* Frames to skip (= render but not save) */
 #define ARGS_REDUCE_POTENTIAL_DEFAULT  ((double)1E1)      /* Pre-simulation target potential energy */
+#define ARGS_SRAND_SEED_DEFAULT        ((unsigned int)time(NULL))  /* Seed for SRAND */
 
 typedef struct args_s args_t;
 struct args_s
@@ -53,6 +55,7 @@ struct args_s
   double reduce_potential;   /* (pJ)       Maximum potential energy before simulating */
   uint64_t frameskip;        /* (unitless) Frameskip */
   uint8_t numerical;         /* (unitless) Force computation mode */
+  uint64_t srand_seed;        /* (unitless) Seed to give to srand for setting RNG seed */
 
   /* Chemical properties, thermodynamics */
   uint64_t copies;           /* (unitless) Substrate copies to be simulated */

--- a/sources/args.c
+++ b/sources/args.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <time.h>
 
 #include "config.h"
 #include "args.h"
@@ -35,6 +36,7 @@ args_t *args_init(args_t *args)
   args->density = ARGS_DENSITY_DEFAULT;
   args->frameskip = ARGS_FRAMESKIP_DEFAULT;
   args->reduce_potential = ARGS_REDUCE_POTENTIAL_DEFAULT;
+  args->srand_seed = ARGS_SRAND_SEED_DEFAULT;
   return (args);
 }
 
@@ -182,6 +184,11 @@ args_t *args_parse(args_t *args, int argc, char **argv)
     else if (!strcmp(argv[i], FLAG_MODEL) && (i+1)<argc)
     {
       args->path_model = argv[++i];
+    }
+
+    else if (!strcmp(argv[i], FLAG_SRAND_SEED) && (i+1)<argc)
+    {
+      args->srand_seed = strtoul(argv[++i], NULL, 10);
     }
 
     else if (i == (argc-1))

--- a/sources/main.c
+++ b/sources/main.c
@@ -7,7 +7,6 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <time.h>
 #include <math.h>
 
 #include "universe.h"
@@ -20,9 +19,6 @@ int main(int argc, char **argv)
   args_t args;         /* Program arguments (from argv) */
   universe_t universe; /* The universe itself (wow) */
 
-  /* We don't need a perfectly random generator */
-  srand((unsigned int)time(NULL));
-
   /* That's the welcome message */
   puts(TEXT_START);
 
@@ -32,6 +28,7 @@ int main(int argc, char **argv)
   {
     return (retstri(EXIT_FAILURE, TEXT_MAIN_FAILURE, __FILE__, __LINE__));
   }
+  srand (args.srand_seed);
 
   /* Initialise the universe with the arguments */
   if (universe_init(&universe, &args) == NULL)


### PR DESCRIPTION
Previously, simulations could not be replicated in a practical manner due to the program selecting a random-enough seed each time.  This adds the `--srand` option, which allows the user to specify a seed.