### PR TITLE
Fix README documentation URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Documentation is available on the [Official SENPAI website](https://senpaimd.org
 
 [Installation Manual](https://senpaimd.org/manuals/installation)
 
-[Your first simulation](https://senpaimd.org/senpai/manuals/first-simulation)
+[Your first simulation](https://senpaimd.org/manuals/first-simulation)
 
-[Creating substrates](https://senpaimd.org/senpai/manuals/creating-substrates)
+[Creating substrates](https://senpaimd.org/manuals/creating-substrates)
 
-[Creating models](https://senpaimd.org/senpai/manuals/creating-models)
+[Creating models](https://senpaimd.org/manuals/mdm-format)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,6 @@ Documentation is available on the [Official SENPAI website](https://senpaimd.org
 
 [Your first simulation](https://senpaimd.org/manuals/first-simulation)
 
-[Creating substrates (MDS files)](https://senpaimd.org/manuals/creating-substrates)
+[Creating substrates (MDS files)](https://senpaimd.org/manuals/mds-format/)
 
 [Creating models (MDM files)](https://senpaimd.org/manuals/mdm-format)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,6 @@ Documentation is available on the [Official SENPAI website](https://senpaimd.org
 
 [Your first simulation](https://senpaimd.org/manuals/first-simulation)
 
-[Creating substrates](https://senpaimd.org/manuals/creating-substrates)
+[Creating substrates (MDS files)](https://senpaimd.org/manuals/creating-substrates)
 
-[Creating models](https://senpaimd.org/manuals/mdm-format)
+[Creating models (MDM files)](https://senpaimd.org/manuals/mdm-format)


### PR DESCRIPTION
In the documentation section of the [`README.md`](./README.md), there were broken URLs. I simply fixed those.

I also updated the titles to match those on the websites.